### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Builds
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fernforestgames/luau-gdextension/security/code-scanning/4](https://github.com/fernforestgames/luau-gdextension/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow. This can be positioned at the root level (applies to **all jobs**) or under each job if their permissions requirements differ. In this case, none of the steps shown require write access to the repository contents, issues, or pull requests; the steps focus on building and uploading artifacts. For uploading artifacts, only the `contents: read` permission is needed (the `actions/upload-artifact` action does not require write permissions). Therefore, you should add the following at the root level (right after `name:` or before `env:`):  
```yaml
permissions:
  contents: read
```
If a job in future needs more, you can override at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
