### PR TITLE
Free bytecode returned by luau_compile

### DIFF
--- a/src/luau.cpp
+++ b/src/luau.cpp
@@ -3,6 +3,7 @@
 #include "helpers.h"
 #include "lua_compileoptions.h"
 
+#include <cstdlib>
 #include <godot_cpp/core/class_db.hpp>
 #include <luacode.h>
 
@@ -86,12 +87,20 @@ PackedByteArray Luau::compile(const String &p_source_code, const LuaCompileOptio
     CharString utf8 = p_source_code.utf8();
     lua_CompileOptions options = p_options ? p_options->get_options() : LuaCompileOptions::default_options();
 
-    size_t bytecode_size;
+    size_t bytecode_size = 0;
     char *bytecode = luau_compile(utf8.get_data(), utf8.length(), &options, &bytecode_size);
+    if (!bytecode)
+    {
+        return PackedByteArray();
+    }
 
     PackedByteArray result;
     result.resize(bytecode_size);
-    memcpy(result.ptrw(), bytecode, bytecode_size);
+    if (bytecode_size > 0)
+    {
+        memcpy(result.ptrw(), bytecode, bytecode_size);
+    }
+    std::free(bytecode);
     return result;
 }
 


### PR DESCRIPTION
## Summary

- release the allocation returned by `luau_compile()` after copying it into a `PackedByteArray`
- handle a null compiler result and avoid copying a zero-length buffer defensively

## Why

Luau's `luacode.h` documents that callers must destroy the buffer returned by `luau_compile()` with `free()`. `Luau::compile()` copied that buffer into Godot-owned storage but did not release the original allocation, leaking once per compilation.

This is intentionally limited to the ownership fix and does not change the public API.

## Validation

- configured with `cmake --preset linux-x86_64-debug`
- built `gdluau` and `gdluau_tests`
- ran `ctest --preset linux-x86_64-debug`
  - 295 native test cases / 11,574 assertions passed
  - 207 GDScript test cases / 713 assertions passed
